### PR TITLE
Firefox fix #12

### DIFF
--- a/internal/poll/poll_option.go
+++ b/internal/poll/poll_option.go
@@ -26,7 +26,7 @@ var option = `<svg width="448px" height="58px" viewBox="0 0 448 58" version="1.1
                       fill="freeze"
                       calcMode="spline"
                       keyTimes="0; 1"
-                      keySplines="0.3, 0.61, 0.355, 1.1" />
+                      keySplines="0.3, 0.61, 0.355, 1" />
                 </rect>
                 <text id="100%" font-family="{{.FontFamily}}" font-size="12" font-weight="normal" letter-spacing="1.857333" fill="#212529">
                     <tspan x="344" y="30">{{.Percent}}%</tspan>


### PR DESCRIPTION
Fix the Firefox implementation by removing the bounce feature. According to [the MDN doc](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/keySplines):

```
 The values of x1 y1 x2 y2 must all be in the range 0 to 1.
```

So I propose changing it to fix Firefox version. [See #12 for more info](https://github.com/tj/gh-polls/issues/12)